### PR TITLE
Moving urg_node_msgs repo to ros-drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.5)
+project(urg_node_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++14")
+
+# Dynamic reconfigure support
+#generate_dynamic_reconfigure_options(cfg/URG.cfg)
+
+rosidl_generate_interfaces(urg_node_msgs
+  "msg/Status.msg"
+  DEPENDENCIES builtin_interfaces std_msgs 
+)
+
+# Install mapping rules for the ros1_bridge
+install(
+  FILES mapping_rules.yaml
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Brett
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # urg_node_msgs
+ROS 2 messages pertaining to the urg_node package

--- a/mapping_rules.yaml
+++ b/mapping_rules.yaml
@@ -1,0 +1,7 @@
+# This file defines mappings between ROS 1 and ROS 2 interfaces.
+# It is used with the ros1_bridge to allow for communcation between ROS 1 and ROS 2.
+
+-
+  ros1_package_name: 'urg_node'
+  ros2_package_name: 'urg_node_msgs'
+

--- a/msg/Status.msg
+++ b/msg/Status.msg
@@ -1,0 +1,17 @@
+# Normal vs setting in the UAM manual.
+uint16 NORMAL=0
+uint16 SETTING=1
+uint16 operating_mode
+
+# The configured area number the stop occurred in.
+uint16 area_number
+# If the laser is reporting an error or not.
+bool error_status
+# The error code the laser is reporting.
+uint16 error_code
+# Does the laser report that it is locked out.
+bool lockout_status
+# Distance in mm the stop was reported at.
+uint16 distance
+# The reported angle of the stop in deg.
+float32 angle

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>urg_node_msgs</name>
+  <version>0.1.10</version>
+  <description>urg_node_msgs</description>
+
+  <maintainer email="tony.baltovski@gmail.com">Tony Baltovski</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://ros.org/wiki/urg_node</url>
+  <url type="bugtracker">https://github.com/ros-drivers/urg_node/issues</url>
+  <url type="repository">https://github.com/ros-drivers/urg_node</url>
+
+  <author email="chadrockey@gmail.com">Chad Rockey</author>
+  <author email="modriscoll@clearpath.ai">Mike O'Driscoll</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>std_msgs</depend>
+  <depend>builtin_interfaces</depend>
+  <depend>rosidl_default_generators</depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <ros1_bridge mapping_rules="mapping_rules.yaml"/>
+  </export>
+</package>


### PR DESCRIPTION
Following this discussion : https://github.com/ros-drivers/urg_node/issues/40
I'm creating this PR to move the `urg_node_msgs` repo to `ros-drivers`.

Since I couldn't transfer ownership, I had to fork this "new" repo, `remote add` and then `fetch` my repo and finally `merge` so that we could keep the commits but we may still have lost some information since it's a new repo (e.g.: other forks).

If you don't care about this, it's fine by me...  
But if you care and have a better way to do it, I'll be happy to do another PR, otherwise I could also give you the ownership @tonybaltovski and you could transfer the "old" repo to `ros-drivers`.
