### PR TITLE
AUTO-727 added contamination warning to status message

### DIFF
--- a/msg/Status.msg
+++ b/msg/Status.msg
@@ -15,3 +15,5 @@ bool lockout_status
 uint16 distance
 # The reported angle of the stop in deg.
 float32 angle
+# The contamination warning status
+bool contamination_warning


### PR DESCRIPTION
[JIRA-LINK](https://dexory.atlassian.net/browse/AUTO-727)

This PR adds a boolean variable for the contamination warning to the urg_node status message. 

This goes together with [PR-11](https://github.com/botsandus/urg_node/pull/11)