### PR TITLE
Added msg fields for the different warning and safety zones

### DIFF
--- a/msg/Status.msg
+++ b/msg/Status.msg
@@ -11,6 +11,13 @@ bool error_status
 uint16 error_code
 # Does the laser report that it is locked out.
 bool lockout_status
+# State of the different warning and safety zones
+bool ossd_1
+bool ossd_2
+bool warning_1
+bool warning_2
+bool ossd_3
+bool ossd_4
 # Distance in mm the stop was reported at.
 uint16 distance
 # The reported angle of the stop in deg.


### PR DESCRIPTION
To be able to use the safety features of the laserscanners, it is necessary to be able to access all warning and ossd states the scanner calculates and transmits.